### PR TITLE
Skip paths matching the paths in .gitignore

### DIFF
--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -49,6 +49,9 @@ var generateCmd = &cobra.Command{
 		if err := c.Load(configPath); err != nil {
 			return err
 		}
+		if err := c.LoadGitIgnore(); err != nil {
+			return err
+		}
 
 		dir := ""
 		if len(args) == 0 {

--- a/config/config.go
+++ b/config/config.go
@@ -9,6 +9,7 @@ import (
 	"github.com/goccy/go-yaml"
 	"github.com/k1LoW/dirmap/matcher"
 	"github.com/k1LoW/expand"
+	gitignore "github.com/sabhiram/go-gitignore"
 )
 
 var DefaultConfigFilePaths = []string{".dirmap.yml", "dirmap.yml"}
@@ -20,6 +21,8 @@ type Config struct {
 	wd string
 	// config file path
 	path string
+
+	GitIgnore *gitignore.GitIgnore
 }
 
 type Target struct {
@@ -99,4 +102,17 @@ func (c *Config) Load(path string) error {
 
 func (c *Config) Loaded() bool {
 	return c.path != ""
+}
+
+func (c *Config) LoadGitIgnore() error {
+	_, err := os.Stat(".gitignore")
+	if err != nil {
+		return nil // Ignore when .gitignore does not exist
+	}
+	ignore, err := gitignore.CompileIgnoreFile(".gitignore")
+	if err != nil {
+		return err
+	}
+	c.GitIgnore = ignore
+	return nil
 }

--- a/scanner/scanner.go
+++ b/scanner/scanner.go
@@ -38,6 +38,11 @@ func Scan(c *config.Config, fsys fs.FS) (fstest.MapFS, error) {
 		if filepath.Base(path) == ".git" {
 			return fs.SkipDir
 		}
+
+		if c.GitIgnore.MatchesPath(path) {
+			return fs.SkipDir
+		}
+
 		for _, p := range c.Ignores {
 			match, _ := doublestar.PathMatch(p, path)
 			if match {


### PR DESCRIPTION
First, thanks to the very useful tool you developed.

I'd like to dirmap not showing the paths that matches the paths in .gitignore.

So I added the function to skip the paths matching the paths in .gitignore.

Please check it.
