### PR TITLE
Check c.GitIgnore is nil or not

### DIFF
--- a/scanner/scanner.go
+++ b/scanner/scanner.go
@@ -39,7 +39,7 @@ func Scan(c *config.Config, fsys fs.FS) (fstest.MapFS, error) {
 			return fs.SkipDir
 		}
 
-		if c.GitIgnore.MatchesPath(path) {
+		if c.GitIgnore != nil && c.GitIgnore.MatchesPath(path) {
 			return fs.SkipDir
 		}
 


### PR DESCRIPTION
This is the bug fix of #2.

When .gitignore file does not exist, `c.GitIgnore` is `nil` and `c.GitIgnore.MatchPath()` causes nil pointer dereference error.

So I add the code to check `c.GitIgnore` is nil or not.

Please check this.
