### PR TITLE
Fix for not ignoring directories that should be ignored when outputting in tree format

### DIFF
--- a/output/tree.go
+++ b/output/tree.go
@@ -25,6 +25,9 @@ func WriteTree(fsys fs.FS, wr io.Writer) error {
 		if err != nil {
 			return err
 		}
+		if di.Sys() != nil && di.Sys().(*scanner.DirInfo).Ignore {
+			return nil
+		}
 		name := fmt.Sprintf("%s/", d.Name())
 		if di.Sys() != nil && !di.Sys().(*scanner.DirInfo).Ignore {
 			dirInfo := di.Sys().(*scanner.DirInfo)


### PR DESCRIPTION
When outputting in tree format, the `ignores` directory names were added to the tree.

I reproduced this bug under this repository, and ran by `$ dirmap generate -t tree`.  Used`.dirmap.yml` is the following.

```yaml
targets:
  - file: .dirmap.md
    matcher: markdown
  - file: README.md
    matcher: markdown
  - file: doc.go
    matcher: godoc
  - file: "*.go"
    matcher: godoc
ignores:
  - version
  - version/**/*
```

# Before
```console
.
├── .github/
│   └── workflows/
├── cmd/ ... Commands.
├── config/ ... Configuration file.
├── matcher/ ... Implementation to find the string that will be the overview from the code or Markdown.
├── output/ ... Output format of the directory map.
├── scanner/ ... Implementation of scanning the target directory and its overview from the file system based on the configuration.
├── scripts/ ... Scripts for Dockerfile.
└── version/
```

# After 
```console
.
├── .github/
│   └── workflows/
├── cmd/ ... Commands.
├── config/ ... Configuration file.
├── matcher/ ... Implementation to find the string that will be the overview from the code or Markdown.
├── output/ ... Output format of the directory map.
├── scanner/ ... Implementation of scanning the target directory and its overview from the file system based on the configuration.
└── scripts/ ... Scripts for Dockerfile.
```