### PR TITLE
Load all .gitignores before scanning

### DIFF
--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -49,9 +49,6 @@ var generateCmd = &cobra.Command{
 		if err := c.Load(configPath); err != nil {
 			return err
 		}
-		if err := c.LoadGitIgnore(); err != nil {
-			return err
-		}
 
 		dir := ""
 		if len(args) == 0 {
@@ -60,6 +57,9 @@ var generateCmd = &cobra.Command{
 			dir = args[0]
 		}
 		fsys := os.DirFS(dir)
+		if err := c.LoadGitIgnore(fsys); err != nil {
+			return err
+		}
 		dmfs, err := scanner.Scan(c, fsys)
 		if err != nil {
 			return err


### PR DESCRIPTION
## Motivation
I'm dealing with a mixed Go and Rust project and noticed that I had written a .gitignore under the rust/ directory and it was not being applied.

## What this change does
1. Recursively searching for all .gitignore files throughout the project's directory structure.
2. Merging these files into a single temporary file, with each own prefixes
3. Creating a gitignore object from this temporary file at the beginning of the scan. 

For example, if the project's root .gitignore contains:
```
a/
b/
```

And a nested .gitignore in ./rust/ contains:
```
target/**
```

The temporary file will compile these rules into:
```
a/
b/
rust/target/**
```